### PR TITLE
Add an option to not render config if there's only one permutation

### DIFF
--- a/src/common/src/types/test_cases_builder.rs
+++ b/src/common/src/types/test_cases_builder.rs
@@ -13,6 +13,14 @@ pub struct TestCasesBuilder {
     pub labels: Option<Vec<String>>,
     /// The permutations to apply to the test cases.
     pub permutations: HashMap<String, Vec<String>>,
+    /// The minimum level of permutations to render in a test case
+    #[serde(default = "default_min_permutations_to_render")]
+    pub minimum_permutations_to_render: u32,
+}
+
+/// Default minimum number of permutations to render
+fn default_min_permutations_to_render() -> u32 {
+    0
 }
 
 impl TestCasesBuilder {
@@ -48,6 +56,7 @@ impl TestCasesBuilder {
             ],
             labels: Some(vec!["Demo".to_string()]),
             permutations,
+            minimum_permutations_to_render: default_min_permutations_to_render(),
         }
     }
 }

--- a/src/yatm_v2/src/helpers/make_test_cases.rs
+++ b/src/yatm_v2/src/helpers/make_test_cases.rs
@@ -98,6 +98,7 @@ mod test_make_test_cases {
                 );
                 m
             },
+            minimum_permutations_to_render: 0,
         };
         let result = make_test_cases_helper(&test_cases_builder, &requirements);
         let expected = vec![
@@ -187,6 +188,7 @@ mod test_make_test_cases {
                 );
                 m
             },
+            minimum_permutations_to_render: 0,
         };
         let result = make_test_cases_helper(&test_cases_builder, &requirements);
         let expected = vec![
@@ -262,6 +264,7 @@ mod test_make_test_cases {
                 negate: false,
             })],
             permutations: Default::default(),
+            minimum_permutations_to_render: 0,
         };
         let result = make_test_cases_helper(&test_cases_builder, &requirements);
         let expected: Vec<TestCase> = vec![];
@@ -421,6 +424,7 @@ mod test_get_selected_requirements {
                 negate: false,
             })],
             permutations: Default::default(),
+            minimum_permutations_to_render: 0,
         };
         let result = get_selected_requirements(&requirements, &test_cases_builder);
         let expected: Vec<Requirement> = vec![];
@@ -455,6 +459,7 @@ mod test_get_selected_requirements {
                 negate: false,
             })],
             permutations: Default::default(),
+            minimum_permutations_to_render: 0,
         };
         let result = get_selected_requirements(&requirements, &test_cases_builder);
         let expected = vec![requirements[0].clone()];
@@ -496,6 +501,7 @@ mod test_get_selected_requirements {
                 }),
             ],
             permutations: Default::default(),
+            minimum_permutations_to_render: 0,
         };
         let result = get_selected_requirements(&requirements, &test_cases_builder);
         let expected = requirements.clone();
@@ -537,6 +543,7 @@ mod test_get_selected_requirements {
                 }),
             ],
             permutations: Default::default(),
+            minimum_permutations_to_render: 0,
         };
         let result = get_selected_requirements(&requirements, &test_cases_builder);
         let expected = vec![requirements[0].clone()];
@@ -583,6 +590,7 @@ mod test_get_selected_requirements {
                 }),
             ],
             permutations: Default::default(),
+            minimum_permutations_to_render: 0,
         };
         let result = get_selected_requirements(&requirements, &test_cases_builder);
         let expected = vec![];

--- a/src/yatm_v2/src/helpers/test_case_to_markdown.rs
+++ b/src/yatm_v2/src/helpers/test_case_to_markdown.rs
@@ -11,6 +11,7 @@ struct GithubIssueTemplate {
     steps: Vec<Step>,
     links: Vec<Link>,
     selected_permutation: HashMap<String, String>,
+    minimum_permutations_to_render: usize,
 }
 
 pub fn test_case_to_markdown(
@@ -24,6 +25,8 @@ pub fn test_case_to_markdown(
         steps: test_case.requirement.steps,
         links: test_case.requirement.links.unwrap_or_default(),
         selected_permutation: test_case.selected_permutation,
+        minimum_permutations_to_render: test_case.builder_used.minimum_permutations_to_render
+            as usize,
     };
     let text_body = template.render().context("Failed to render the template")?;
 

--- a/src/yatm_v2/templates/github_issue.md
+++ b/src/yatm_v2/templates/github_issue.md
@@ -1,6 +1,6 @@
 {{ description }}
 
-{% if selected_permutation.len() > 0 -%}
+{% if selected_permutation.len() > minimum_permutations_to_render -%}
 ## Configuration
 
 {% for (key, value) in selected_permutation -%}


### PR DESCRIPTION
I left this with the default behavior unchanged and the option to set it to 1 which is the one that makes the most sense I think. But I would also consider that changing the default to 1 might make sense. 

Fixes https://github.com/tfoote/yatm-v2/issues/1

I'm still learning Rust so haven't grokked how to effectively add testing coverage for this.