### PR TITLE
Add the ability to reverse the issue order on upload to github.

### DIFF
--- a/src/yatm_v2/Cargo.toml
+++ b/src/yatm_v2/Cargo.toml
@@ -14,6 +14,7 @@ chrono = "0.4.33"
 clap = { version = "4.4.18", features = ["derive"] }
 common = { path = "../common" }
 dotenv = "0.15.0"
+either = "1.15.0"
 itertools = "0.12.1"
 octocrab = "0.33.4"
 percent-encoding = "2.3.1"


### PR DESCRIPTION
This helps if the test cases are approximately ordered, and because github sorts by default from newest to oldest, this will cause the first issues to appear at the top, versus at the bottom being the lowest numbered and oldest.