### PR TITLE
automatically generate the output directory in case it doesn't exist.

### DIFF
--- a/src/yatm_v2/src/app/cli.rs
+++ b/src/yatm_v2/src/app/cli.rs
@@ -448,6 +448,10 @@ pub async fn cli() -> Result<()> {
                 let datetime_string = chrono::Local::now().format("%Y-%m-%d-%H-%M-%S").to_string();
                 let output_file_name = format!("test-cases-{}.md", datetime_string);
                 let output_path = config.generated_files_dir.join(output_file_name);
+                std::fs::create_dir_all(&config.generated_files_dir).context(format!(
+                    "Failed to create generated files dir: {:?}",
+                    config.generated_files_dir
+                ))?;
                 std::fs::write(&output_path, file_contents).context(format!(
                     "Failed to write the test cases file: {:?}",
                     output_path


### PR DESCRIPTION
This was just a pain point for easy first time usage.