### PR TITLE
Provide output to show what repo is being interacted with

### DIFF
--- a/src/common/src/github.rs
+++ b/src/common/src/github.rs
@@ -199,4 +199,16 @@ impl Github {
             ))?;
         Ok(())
     }
+
+    pub fn prepend_github_info(
+        &self,
+        content: &String,
+    ) -> String {
+        let header = format!("# Github Target\n\nrepository: [{}/{}](https://github.com/{}/{})", self.owner, self.repo, self.owner, self.repo);
+        if header.is_empty() {
+            return content.clone();
+        }
+        format!("{}\n\n{}", header, content)
+    }
 }
+

--- a/src/yatm_v2/src/app/cli.rs
+++ b/src/yatm_v2/src/app/cli.rs
@@ -443,6 +443,9 @@ pub async fn cli() -> Result<()> {
                 };
                 file_contents =
                     prepend_markdown_table_of_contents(&file_contents, Some(&toc_options));
+                let gh = Github::new(&config.repo_owner, &config.repo_name)?;
+                
+                file_contents = gh.prepend_github_info(&file_contents);
 
                 // Write the test cases to a file
                 let datetime_string = chrono::Local::now().format("%Y-%m-%d-%H-%M-%S").to_string();

--- a/src/yatm_v2/src/app/cli.rs
+++ b/src/yatm_v2/src/app/cli.rs
@@ -480,6 +480,7 @@ pub async fn cli() -> Result<()> {
 
                 // Get the issues from Github
                 let gh = Github::new(&config.repo_owner, &config.repo_name)?;
+                println!("Connecting to repository: {}/{}", config.repo_owner, config.repo_name);
                 let github_issues = gh.get_issues(Some(State::Open)).await?;
 
                 // Create issues that don't exist on Github


### PR DESCRIPTION
Both in the console output  as well as in the generated preview