### PR TITLE
include the config value in the filename for traceabilty

### DIFF
--- a/src/yatm_v2/src/app/cli.rs
+++ b/src/yatm_v2/src/app/cli.rs
@@ -454,7 +454,11 @@ pub async fn cli() -> Result<()> {
 
                 // Write the test cases to a file
                 let datetime_string = chrono::Local::now().format("%Y-%m-%d-%H-%M-%S").to_string();
-                let output_file_name = format!("test-cases-{}.md", datetime_string);
+                let output_file_name = format!(
+                    "{}--generated-test-cases--{}.md",
+                    &config_path.display(),
+                    datetime_string
+                );
                 let output_path = config.generated_files_dir.join(output_file_name);
                 std::fs::create_dir_all(&config.generated_files_dir).context(format!(
                     "Failed to create generated files dir: {:?}",

--- a/src/yatm_v2/src/app/cli.rs
+++ b/src/yatm_v2/src/app/cli.rs
@@ -14,6 +14,7 @@ use common::types::{Link, RequirementsFile, TestCasesBuilderFile};
 
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::ffi::OsStr;
 
 use anyhow::{Context, Ok, Result};
 use clap::{Parser, Subcommand};
@@ -455,8 +456,8 @@ pub async fn cli() -> Result<()> {
                 // Write the test cases to a file
                 let datetime_string = chrono::Local::now().format("%Y-%m-%d-%H-%M-%S").to_string();
                 let output_file_name = format!(
-                    "{}--generated-test-cases--{}.md",
-                    &config_path.display(),
+                    "config_path--{}--generated-test-cases--{}.md",
+                    &config_path.file_prefix().unwrap_or(OsStr::new("undefined")).display(),
                     datetime_string
                 );
                 let output_path = config.generated_files_dir.join(output_file_name);

--- a/src/yatm_v2/src/app/cli.rs
+++ b/src/yatm_v2/src/app/cli.rs
@@ -13,8 +13,8 @@ use common::markdown_toc::{prepend_markdown_table_of_contents, TocOptions};
 use common::types::{Link, RequirementsFile, TestCasesBuilderFile};
 
 use std::collections::HashSet;
-use std::path::PathBuf;
 use std::ffi::OsStr;
+use std::path::PathBuf;
 
 use anyhow::{Context, Ok, Result};
 use clap::{Parser, Subcommand};
@@ -457,7 +457,10 @@ pub async fn cli() -> Result<()> {
                 let datetime_string = chrono::Local::now().format("%Y-%m-%d-%H-%M-%S").to_string();
                 let output_file_name = format!(
                     "config_path--{}--generated-test-cases--{}.md",
-                    &config_path.file_prefix().unwrap_or(OsStr::new("undefined")).display(),
+                    &config_path
+                        .file_prefix()
+                        .unwrap_or(OsStr::new("undefined"))
+                        .display(),
                     datetime_string
                 );
                 let output_path = config.generated_files_dir.join(output_file_name);


### PR DESCRIPTION
If you have multiple/many configs it's important to tell them apart. Otherwise you just end up with a bunch of files in a directory that are not distinguishable. 